### PR TITLE
clojure.walk was not explicitly requried

### DIFF
--- a/src/clj_jade/core.clj
+++ b/src/clj_jade/core.clj
@@ -1,4 +1,5 @@
 (ns clj-jade.core
+  (:require clojure.walk)
   (:import [de.neuland.jade4j JadeConfiguration]
            [de.neuland.jade4j.template FileTemplateLoader]))
 


### PR DESCRIPTION
clojure.walk was not explicitly required and caused an exception when loaded
