### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ define helpers for date formatting, rounding etc.
 !!! 5
 html
   body
-    h1 #(helpers.math.round(number))
+    h1 #{helpers.math.round(number)}
 ```
 
 ```clojure


### PR DESCRIPTION
Typo in the example for invoking a helper in a Jade template. Should be in curly braces '{}' but is in normal parentheses '()'