### PR TITLE
Allowing  core/render to be called without an explicit empty map if no params are needed

### DIFF
--- a/examples/templates/noparam.jade
+++ b/examples/templates/noparam.jade
@@ -1,0 +1,7 @@
+extends layout
+
+block scripts
+  script(src="/page/specific.js", type="text/javascript")
+
+block content
+  h1 Hello no passed params

--- a/src/clj_jade/core.clj
+++ b/src/clj_jade/core.clj
@@ -54,5 +54,6 @@
   (.getTemplate @config template-path))
 
 (defn render
-  [template-path data]
-  (.renderTemplate @config (template template-path) (clojure.walk/stringify-keys data)))
+  ([template-path] (render template-path {}))
+  ([template-path data]
+  (.renderTemplate @config (template template-path) (clojure.walk/stringify-keys data))))

--- a/test/clj_jade/core_test.clj
+++ b/test/clj_jade/core_test.clj
@@ -12,6 +12,9 @@
 
   (testing "Parameter substitution with clojure keywords as keys"
     (is (.contains (jade/render "examples/templates/home.jade" {:name "Jade"}) "Hello Jade")))
+  
+  (testing "Rendering a page without passing the parameters map"
+    (is (.contains (jade/render "examples/templates/noparam.jade") "Hello no passed params")))
 
   (testing "with base template directory specified"
     (jade/configure {:template-dir "examples/templates/"})


### PR DESCRIPTION
Currently if there's no parameters to be passed to core/render we have to do:

``` clojure
(core/render "mytemplate" {})
```

This change will allow instead to do:

``` clojure
(core/render "mytemplate")
```
